### PR TITLE
Include core size stats

### DIFF
--- a/bin/add_percent_used.py
+++ b/bin/add_percent_used.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import sys
+
+def main(args):
+
+    output_fieldnames = [
+        'ID',
+        'LENGTH',
+        'ALIGNED',
+        'UNALIGNED',
+        'VARIANT',
+        'HET',
+        'MASKED',
+        'LOWCOV',
+        'PERCENT_USED',
+    ]
+    writer = csv.DictWriter(sys.stdout, fieldnames=output_fieldnames, dialect='excel-tab')
+    writer.writeheader()
+    
+    with open(args.input, 'r') as f:
+        reader = csv.DictReader(f, dialect='excel-tab')
+        for row in reader:
+            if int(row['LENGTH']) > 0:
+                row['PERCENT_USED'] = round(100 * int(row['ALIGNED']) / int((row['LENGTH'])), 2)
+            else:
+                row['PERCENT_USED'] = 0.0
+
+            writer.writerow(row)
+
+    
+    
+    
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input')
+    args = parser.parse_args()
+    main(args)

--- a/modules/snippy_core.nf
+++ b/modules/snippy_core.nf
@@ -1,6 +1,7 @@
 process snippy_core {
     publishDir "${params.outdir}", mode: 'copy', pattern: "*.aln"
     publishDir "${params.outdir}", mode: 'copy', pattern: "core.vcf"
+    publishDir "${params.outdir}", mode: 'copy', pattern: "core.tsv"
 
     input:
     tuple path(snippy_dirs), path(ref), path(mask)
@@ -8,6 +9,7 @@ process snippy_core {
     output:
     path('core.aln'), emit: core_alignment
     path('core.vcf'), emit: core_variants
+    path('core.tsv'), emit: core_stats
     path('core.full.aln'), emit: full_alignment
     path('clean.full.aln'), emit: clean_full_alignment
 
@@ -19,5 +21,7 @@ process snippy_core {
       $snippy_dirs
 
     snippy-clean_full_aln core.full.aln > clean.full.aln
+
+    add_percent_used.py core.txt > core.tsv
     """
 }


### PR DESCRIPTION
Fixes #4 

This PR also adds a helper script `add_percent_used.py` which calculates the '% Used' column in the same way that is done in nullarbor:

https://github.com/tseemann/nullarbor/blob/523d975c278f81e5e4095a3b50dfd832ddef40fa/perl5/Nullarbor/Module/core.pm#L36