### PR TITLE
Matrix table fix

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -26,16 +26,29 @@ workflow {
     ch_mask = Channel.fromPath(params.mask)
   }
 
+  
+
   main:
 
   snippy_core(ch_snippy_dirs.collect().combine(ch_ref).map{ it -> [it[0..-2], it[-1]] }.combine(ch_mask))
 
+  
   if (!params.skip_gubbins) {
+  
     gubbins(snippy_core.out.clean_full_alignment)
-    ch_alignment = gubbins.out.filtered_polymorphic_sites
+
+    if (gubbins.out.filtered_polymorphic_sites != null) {
+      ch_alignment = gubbins.out.filtered_polymorphic_sites
+    } else {
+    ch_alignment = snippy_core.out.clean_full_alignment
+  }
+
+    
   } else {
     ch_alignment = snippy_core.out.clean_full_alignment
   }
+   
+
 
   snp_sites(ch_alignment)
 

--- a/main.nf
+++ b/main.nf
@@ -36,20 +36,16 @@ workflow {
   if (!params.skip_gubbins) {
   
     gubbins(snippy_core.out.clean_full_alignment)
-
     if (gubbins.out.filtered_polymorphic_sites != null) {
       ch_alignment = gubbins.out.filtered_polymorphic_sites
     } else {
     ch_alignment = snippy_core.out.clean_full_alignment
-  }
+    }
 
-    
   } else {
     ch_alignment = snippy_core.out.clean_full_alignment
   }
    
-
-
   snp_sites(ch_alignment)
 
   iqtree(snp_sites.out)

--- a/main.nf
+++ b/main.nf
@@ -34,14 +34,18 @@ workflow {
 
   
   if (!params.skip_gubbins) {
+
+
   
-    gubbins(snippy_core.out.clean_full_alignment)
-    if (gubbins.out.filtered_polymorphic_sites != null) {
+    gubbins(snippy_core.out.clean_full_alignment, snippy_core.out.run_gubbins)
+    
+    if (snippy_core.out.run_gubbins == "true") {
       ch_alignment = gubbins.out.filtered_polymorphic_sites
     } else {
     ch_alignment = snippy_core.out.clean_full_alignment
     }
 
+    
   } else {
     ch_alignment = snippy_core.out.clean_full_alignment
   }

--- a/main.nf
+++ b/main.nf
@@ -34,22 +34,16 @@ workflow {
 
   
   if (!params.skip_gubbins) {
-
-
-  
     gubbins(snippy_core.out.clean_full_alignment, snippy_core.out.run_gubbins)
-    
     if (snippy_core.out.run_gubbins == "true") {
       ch_alignment = gubbins.out.filtered_polymorphic_sites
     } else {
-    ch_alignment = snippy_core.out.clean_full_alignment
+      ch_alignment = snippy_core.out.clean_full_alignment
     }
-
-    
   } else {
     ch_alignment = snippy_core.out.clean_full_alignment
   }
-   
+  
   snp_sites(ch_alignment)
 
   iqtree(snp_sites.out)

--- a/modules/gubbins.nf
+++ b/modules/gubbins.nf
@@ -1,14 +1,18 @@
 process gubbins {
+  
+  errorStrategy 'ignore'
 
   publishDir "${params.outdir}", mode: 'copy', pattern: "gubbins.*"
 
   input:
   path(alignment)
 
+
   output:
   path('gubbins.filtered_polymorphic_sites.fasta'), emit: filtered_polymorphic_sites
   path('gubbins.recombination_predictions.gff'),    emit: recombination_predictions_gff
   path('gubbins.per_branch_statistics.tsv'),        emit: per_branch_statistics
+
 
   script:
   """

--- a/modules/gubbins.nf
+++ b/modules/gubbins.nf
@@ -15,7 +15,6 @@ process gubbins {
 
   when:
   run_gubbins == "true"
-  
 
   script:
   """

--- a/modules/gubbins.nf
+++ b/modules/gubbins.nf
@@ -6,13 +6,16 @@ process gubbins {
 
   input:
   path(alignment)
-
+  val(run_gubbins)
 
   output:
   path('gubbins.filtered_polymorphic_sites.fasta'), emit: filtered_polymorphic_sites
   path('gubbins.recombination_predictions.gff'),    emit: recombination_predictions_gff
   path('gubbins.per_branch_statistics.tsv'),        emit: per_branch_statistics
 
+  when:
+  run_gubbins == "true"
+  
 
   script:
   """

--- a/modules/snippy_core.nf
+++ b/modules/snippy_core.nf
@@ -32,13 +32,6 @@ process snippy_core {
     else
         run_gubbins='false'
     fi
-
-
-
-
-    
-
- 
     
     """
 }

--- a/modules/snippy_core.nf
+++ b/modules/snippy_core.nf
@@ -12,7 +12,7 @@ process snippy_core {
     path('core.tsv'), emit: core_stats
     path('core.full.aln'), emit: full_alignment
     path('clean.full.aln'), emit: clean_full_alignment
-
+    val('run_gubbins'), emit: run_gubbins
 
 
     script:
@@ -26,7 +26,19 @@ process snippy_core {
 
     add_percent_used.py core.txt > core.tsv
 
+    num_isolates=\$(echo "\$snippy_dirs" | tr -s ' ' | wc -w)
+    if [ "\$num_isolates" -ge 3 ]; then
+        run_gubbins='true'
+    else
+        run_gubbins='false'
+    fi
 
+
+
+
+    
+
+ 
     
     """
 }

--- a/modules/snippy_core.nf
+++ b/modules/snippy_core.nf
@@ -13,6 +13,8 @@ process snippy_core {
     path('core.full.aln'), emit: full_alignment
     path('clean.full.aln'), emit: clean_full_alignment
 
+
+
     script:
     """
     snippy-core \
@@ -23,5 +25,9 @@ process snippy_core {
     snippy-clean_full_aln core.full.aln > clean.full.aln
 
     add_percent_used.py core.txt > core.tsv
+
+
+    
     """
 }
+


### PR DESCRIPTION
Fixes #6 

Issue occurs when running gubbins on clusters with less than 3 isolates. There is a parameter to skip_gubbins but we only want to skip if there are 2 isolates in a cluster. In production the pipeline is wrapped in a script and not able to be manually updated each time.

Changes:
Adds a boolean value called 'run_gubbins' in snippy_core.nf , set to true if there are 3 or more isolates in the snippy_dirs
Adds to gubbins.nf to run process only when run_gubbins is true, adds errorStrategy 'ignore'
In main.nf, adds run_gubbins variable to gubbins process, and assigns ch_alignment to the gubbins output only if run_gubbins is true, otherwise the snippy core alignment is used